### PR TITLE
#54[고정 일정 폼 변경]/#121-주간캘린더-시간대-변경

### DIFF
--- a/src/main/resources/static/js/home/fullcalendarInit.js
+++ b/src/main/resources/static/js/home/fullcalendarInit.js
@@ -6,8 +6,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const calendar = new FullCalendar.Calendar(calendarEl, {
         initialDate: new Date(),
         initialView: 'dayGridMonth',
-        slotMinTime: '07:00:00',
-        slotMaxTime: '23:59:59',
         nowIndicator: true,
         locale: 'ko',
         headerToolbar: getHeaderToolbarOptions(),


### PR DESCRIPTION
#54 
[Refactor] 주간 캘린더에서 보여주는 시간대 변경
- 주간캘린더를 조회하면 7시에서 23시까지의 시간대가 나옴
- 0시 00분에서 23시 59분까지 모든 시간대를 보여줄 수 있도록 수정